### PR TITLE
Rename ANSIEscapeCodeProcessor to WordProcessor

### DIFF
--- a/src/TerminalFlow/ANSIEscapeCodeProcessor.cs
+++ b/src/TerminalFlow/ANSIEscapeCodeProcessor.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace TerminalFlow.Core
-{
-    public static class ANSIEscapeCodeProcessor
-    {
-        public static void ClearAfterCursor() => Console.Write("\u001b[0J");
-    }
-}

--- a/src/TerminalFlow/ConsoleFlow.cs
+++ b/src/TerminalFlow/ConsoleFlow.cs
@@ -17,15 +17,11 @@ namespace TerminalFlow
 
         private ConsoleVec2 m_StartPosition;
 
-        public ConsoleFlow()
+        public ConsoleFlow(params ConsoleUI[] uis)
         {
-            if(!isInitialized)
+            foreach(var ui in uis)
             {
-                if(Environment.OSVersion.Platform == PlatformID.Win32NT)
-                {
-                    KernelWrapper.EnableVirtualTerminalProcessing();
-                }
-                isInitialized = true;
+                Add(ui);
             }
         }
 
@@ -39,6 +35,15 @@ namespace TerminalFlow
         public void Display()
         {
             Console.CursorVisible = false;
+
+            if(!isInitialized)
+            {
+                if(Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    KernelWrapper.EnableVirtualTerminalProcessing();
+                }
+                isInitialized = true;
+            }
 
             var currentPos = new ConsoleVec2(Console.CursorLeft, Console.CursorTop);
             m_StartPosition = currentPos;
@@ -56,7 +61,7 @@ namespace TerminalFlow
         {
             vec2.Move();
 
-            ANSIEscapeCodeProcessor.ClearAfterCursor();
+            WordProcessor.ClearAfterCursor();
         }
 
         private void OnReceiveResizeEvent(ConsoleUI sender)
@@ -99,7 +104,7 @@ namespace TerminalFlow
         public void Dispose()
         {
             m_StartPosition.Move();
-            ANSIEscapeCodeProcessor.ClearAfterCursor();
+            WordProcessor.ClearAfterCursor();
 
             Console.CursorVisible = true;
         }

--- a/src/TerminalFlow/WordProcessor.cs
+++ b/src/TerminalFlow/WordProcessor.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Text;
+
+namespace TerminalFlow.Core
+{
+    public static class WordProcessor
+    {
+        public static void ClearAfterCursor()
+        {
+            Console.Write("\u001b[0J");
+        }
+
+        public static int GetLength(string s)
+        {
+            return Encoding.UTF8.GetByteCount(s);
+        }
+    }
+}


### PR DESCRIPTION
It is going to be able not only to server ANSI Escape Code but also to support developing.  
On this idea, I think the old name is not good.