### PR TITLE
Implement ConsoleText

### DIFF
--- a/src/TerminalFlow/UI/ConsoleText.cs
+++ b/src/TerminalFlow/UI/ConsoleText.cs
@@ -1,0 +1,24 @@
+using System;
+using TerminalFlow.Core;
+
+namespace TerminalFlow
+{
+    public class ConsoleText : ConsoleUI
+    {
+        public override ConsoleSize Size => m_Size;
+        private ConsoleSize m_Size;
+
+        private string m_Text;
+
+        public ConsoleText(string text)
+        {
+            m_Text = text;
+            m_Size = new ConsoleSize(text.Length, 1);
+        }
+
+        public override void Display()
+        {
+            Console.Write(m_Text);
+        }
+    }
+}


### PR DESCRIPTION
There is `Console.Write()` method, which cannot be used in TerminalFlow.  
It's because, then, the layout is broken.  
With this component, a layout crash no longer occurs.