### PR TITLE
Add a option to give the instance back

### DIFF
--- a/src/TerminalFlow/UI/ConsoleProgressBar.cs
+++ b/src/TerminalFlow/UI/ConsoleProgressBar.cs
@@ -73,6 +73,17 @@ namespace TerminalFlow
             UpdateSize();
         }
 
+        public ConsoleProgressBar(out ConsoleProgressBar bar, string title = "", int length = 10)
+        {
+            m_Title = title;
+            m_Length = length;
+
+            m_ProcessedText = ProcessText();
+            UpdateSize();
+
+            bar = this;
+        }
+
         /// <summary>
         ///
         /// Recalcutate the size.

--- a/src/TerminalFlow/UI/ConsoleRect.cs
+++ b/src/TerminalFlow/UI/ConsoleRect.cs
@@ -31,10 +31,32 @@ namespace TerminalFlow
         }
         private ConsoleColor m_Color;
 
+        public ConsoleRect(int width, int height, ConsoleColor color)
+        {
+            m_Size = new ConsoleSize(width, height);
+            m_Color = color;
+        }
+
         public ConsoleRect(ConsoleSize size, ConsoleColor color)
         {
             m_Size = size;
             m_Color = color;
+        }
+
+        public ConsoleRect(out ConsoleRect rect, int width, int height, ConsoleColor color)
+        {
+            m_Size = new ConsoleSize(width, height);
+            m_Color = color;
+
+            rect = this;
+        }
+
+        public ConsoleRect(out ConsoleRect rect, ConsoleSize size, ConsoleColor color)
+        {
+            m_Size = size;
+            m_Color = color;
+
+            rect = this;
         }
 
         /// <summary>

--- a/src/TerminalFlow/UI/ConsoleText.cs
+++ b/src/TerminalFlow/UI/ConsoleText.cs
@@ -14,12 +14,41 @@ namespace TerminalFlow
         public override ConsoleSize Size => m_Size;
         private ConsoleSize m_Size;
 
+        public ConsoleColor BackgroundColor { get; private set; }
+        public ConsoleColor TextColor { get; private set; }
+
         private string m_Text;
 
         public ConsoleText(string text)
         {
             m_Text = text;
             m_Size = new ConsoleSize(text.Length, 1);
+        }
+
+        public ConsoleText(string text, ConsoleColor textColor, ConsoleColor backgroundColor)
+        {
+            m_Text = text;
+            m_Size = new ConsoleSize(text.Length, 1);
+            TextColor = textColor;
+            BackgroundColor = backgroundColor;
+        }
+
+        public ConsoleText(out ConsoleText consoleText, string text)
+        {
+            m_Text = text;
+            m_Size = new ConsoleSize(text.Length, 1);
+
+            consoleText = this;
+        }
+
+        public ConsoleText(out ConsoleText consoleText, string text, ConsoleColor textColor, ConsoleColor backgroundColor)
+        {
+            m_Text = text;
+            m_Size = new ConsoleSize(text.Length, 1);
+            TextColor = textColor;
+            BackgroundColor = backgroundColor;
+
+            consoleText = this;
         }
 
         public override void Display()


### PR DESCRIPTION
It is no longer required to separate the design section from the logic section.