### PR TITLE
Change the styles of ConsoleProgress

### DIFF
--- a/src/ConsoleFlow/UI/ConsoleProgress.cs
+++ b/src/ConsoleFlow/UI/ConsoleProgress.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ConsoleFlow.Core;
+
+namespace ConsoleFlow
+{
+    /// <summary>
+    ///
+    ///  A simple progress bar which works on Console.
+    ///
+    /// </summary>
+    public class ConsoleProgress : ConsoleUI
+    {
+        private const int TITLE_SPACE_WIDTH = 20;
+        private const int DEFAULT_LENGTH = 50;
+        private const ConsoleColor OK_COLOR = ConsoleColor.Green;
+
+        /// <summary>
+        ///
+        /// The value of the progress bar.
+        ///
+        /// </summary>
+        public float Value
+        {
+            get => m_Value;
+            set
+            {
+                if(m_Value != value)
+                {
+                    m_Value = value;
+                    InvokeRepaint();
+                }
+                else
+                {
+                    m_Value = value;
+                }
+            }
+        }
+        private float m_Value;
+
+        /// <summary>
+        ///
+        /// The title of the progress bar.
+        ///
+        /// </summary>
+        public string Title
+        {
+            get => m_Title;
+            set
+            {
+                if (m_Title != value)
+                {
+                    m_Title = value;
+                    InvokeRepaint();
+                }
+                else
+                {
+                    m_Title = value;
+                }
+            }
+        }
+        private string m_Title;
+
+        /// <summary>
+        ///
+        /// The length of the value-shown part of the progress bar.
+        ///
+        /// </summary>
+        public int Length => m_Length;
+        private int m_Length;
+
+        public override ConsoleSize Size => m_Size;
+        private ConsoleSize m_Size = new ConsoleSize(0, 0);
+
+        public ConsoleProgress(string title = "", int length = DEFAULT_LENGTH)
+        {
+            m_Title = title;
+            m_Length = length;
+
+            UpdateSize();
+        }
+
+        public ConsoleProgress(out ConsoleProgress bar, string title = "", int length = DEFAULT_LENGTH)
+        {
+            m_Title = title;
+            m_Length = length;
+
+            UpdateSize();
+
+            bar = this;
+        }
+
+        /// <summary>
+        ///
+        /// Recalcutate the size.
+        ///
+        /// </summary>
+        protected void UpdateSize()
+        {
+
+            //
+            // Title |**********----------| 50%
+            //
+            int width = TITLE_SPACE_WIDTH + 1 + m_Length + 1 + 4;
+            m_Size = new ConsoleSize(width, 1);
+        }
+
+        public override void Display()
+        {
+            var startPos = ConsoleVec2.Current;
+            var relativePos = new ConsoleVec2(0, 0);
+            (startPos + relativePos).Move();
+
+            Console.Write(m_Title);
+
+            relativePos += new ConsoleVec2(TITLE_SPACE_WIDTH, 0);
+            (startPos + relativePos).Move();
+
+            Console.Write("|");
+
+            int progress = (int)Math.Floor(m_Length * m_Value);
+            Console.BackgroundColor = OK_COLOR;
+            for (int current = 0; current < m_Length; current++)
+            {
+                if(current == progress)
+                {
+                    Console.ResetColor();
+                }
+                Console.Write(" ");
+            }
+            Console.ResetColor();
+
+            Console.Write("|");
+
+            relativePos += new ConsoleVec2(1 + m_Length + 1, 0);
+            (startPos + relativePos).Move();
+
+            Console.Write($"{Math.Floor(m_Value * 100f)}%");
+        }
+    }
+}

--- a/src/ConsoleFlow/UI/ConsoleProgress.cs
+++ b/src/ConsoleFlow/UI/ConsoleProgress.cs
@@ -119,7 +119,7 @@ namespace ConsoleFlow
             relativePos += new ConsoleVec2(TITLE_SPACE_WIDTH, 0);
             (startPos + relativePos).Move();
 
-            Console.Write("|");
+            Console.Write("[");
 
             int progress = (int)Math.Floor(m_Length * m_Value);
             Console.BackgroundColor = OK_COLOR;
@@ -129,11 +129,19 @@ namespace ConsoleFlow
                 {
                     Console.ResetColor();
                 }
-                Console.Write(" ");
+
+                if(current < progress)
+                {
+                    Console.Write(" ");
+                }
+                else
+                {
+                    Console.Write("-");
+                }
             }
             Console.ResetColor();
 
-            Console.Write("|");
+            Console.Write("]");
 
             relativePos += new ConsoleVec2(1 + m_Length + 1, 0);
             (startPos + relativePos).Move();

--- a/src/ConsoleFlow/UI/SimpleProgress.cs
+++ b/src/ConsoleFlow/UI/SimpleProgress.cs
@@ -12,7 +12,7 @@ namespace ConsoleFlow
     ///  A simple progress bar which works on Console.
     ///
     /// </summary>
-    public class ConsoleProgressBar : ConsoleUI
+    public class SimpleProgress : ConsoleUI
     {
         /// <summary>
         ///
@@ -64,7 +64,7 @@ namespace ConsoleFlow
         public override ConsoleSize Size => m_Size;
         private ConsoleSize m_Size = new ConsoleSize(0, 0);
 
-        public ConsoleProgressBar(string title = "", int length = 10)
+        public SimpleProgress(string title = "", int length = 10)
         {
             m_Title = title;
             m_Length = length;
@@ -73,7 +73,7 @@ namespace ConsoleFlow
             UpdateSize();
         }
 
-        public ConsoleProgressBar(out ConsoleProgressBar bar, string title = "", int length = 10)
+        public SimpleProgress(out SimpleProgress bar, string title = "", int length = 10)
         {
             m_Title = title;
             m_Length = length;

--- a/src/Example/ConsoleProgressExample.cs
+++ b/src/Example/ConsoleProgressExample.cs
@@ -1,0 +1,43 @@
+using System;
+
+using ConsoleFlow;
+
+namespace ConsoleFlow.Example
+{
+    partial class Examples
+    {
+        public void ConsoleProgressExample()
+        {
+            var firstProgress = new ConsoleProgress(title: "First", length: 100);
+            var secondProgress = new ConsoleProgress(title: "Second", length: 100);
+
+            var flow = new ConsoleFlow
+            (
+                firstProgress,
+                new ConsoleText(""),
+                secondProgress,
+                new ConsoleText("Press [f] to increment First"),
+                new ConsoleText("Press [s] to increment Second")
+            );
+
+            flow.Display();
+
+            while(true)
+            {
+                var key = Console.ReadKey(true).Key;
+                if (key == ConsoleKey.Escape)
+                {
+                    break;
+                }
+                else if (key == ConsoleKey.F)
+                {
+                    firstProgress.Value = Math.Clamp(firstProgress.Value + 0.1f, 0f, 1f);
+                }
+                else if (key == ConsoleKey.S)
+                {
+                    secondProgress.Value = Math.Clamp(secondProgress.Value + 0.1f, 0f, 1f);
+                }
+            }
+        }
+    }
+}

--- a/src/Example/ProgressBarExample.cs
+++ b/src/Example/ProgressBarExample.cs
@@ -8,8 +8,8 @@ namespace ConsoleFlow.Example
     {
         public void ProgressBarExample()
         {
-            var firstProgress = new ConsoleProgressBar(title: "First", length: 100);
-            var secondProgress = new ConsoleProgressBar(title: "Second", length: 100);
+            var firstProgress = new SimpleProgress(title: "First", length: 100);
+            var secondProgress = new SimpleProgress(title: "Second", length: 100);
 
             var flow = new ConsoleFlow
             (

--- a/src/Example/SimpleProgressExample.cs
+++ b/src/Example/SimpleProgressExample.cs
@@ -6,7 +6,7 @@ namespace ConsoleFlow.Example
 {
     partial class Examples
     {
-        public void ProgressBarExample()
+        public void SimpleProgressExample()
         {
             var firstProgress = new SimpleProgress(title: "First", length: 100);
             var secondProgress = new SimpleProgress(title: "Second", length: 100);


### PR DESCRIPTION
There is an old progress bar whose color is on gray scale.  
It is far from beautiful. Isn't it?  
So, I created a new colorful progress bar and named as "ConsoleProgress".
And now, the old one was renamed to "SimpleProgress".